### PR TITLE
Only allow single instance of tTVPSDLSdlGameControllerMgr::sInstance

### DIFF
--- a/environ/win32/WindowFormUnit.cpp
+++ b/environ/win32/WindowFormUnit.cpp
@@ -501,25 +501,28 @@ void TTVPWindowForm::TickBeat(){
 	if (SdlInputManager && TJSNativeInstance) {
 		SdlInputManager->Update();
 
-		auto it = tTVPSDLSdlGameControllerMgr::sInstance->mControllers.find(0);
-		if (it != tTVPSDLSdlGameControllerMgr::sInstance->mControllers.end())
+		if (tTVPSDLSdlGameControllerMgr::sInstance)
 		{
-			const std::vector<WORD>& uppedkeys = it->second.GetUppedKeys();
-			const std::vector<WORD>& downedkeys = it->second.GetDownedKeys();
-			const std::vector<WORD>& repeatkeys = it->second.GetRepeatKeys();
-			std::vector<WORD>::const_iterator i;
-			
-			// for upped pad buttons
-			for (i = uppedkeys.begin(); i != uppedkeys.end(); i++) {
-				InternalKeyUp(*i, shift);
-			}
-			// for downed pad buttons
-			for (i = downedkeys.begin(); i != downedkeys.end(); i++) {
-				InternalKeyDown(*i, shift);
-			}
-			// for repeated pad buttons
-			for (i = repeatkeys.begin(); i != repeatkeys.end(); i++) {
-				InternalKeyDown(*i, shift | TVP_SS_REPEAT);
+			auto it = tTVPSDLSdlGameControllerMgr::sInstance->mControllers.find(0);
+			if (it != tTVPSDLSdlGameControllerMgr::sInstance->mControllers.end())
+			{
+				const std::vector<WORD>& uppedkeys = it->second.GetUppedKeys();
+				const std::vector<WORD>& downedkeys = it->second.GetDownedKeys();
+				const std::vector<WORD>& repeatkeys = it->second.GetRepeatKeys();
+				std::vector<WORD>::const_iterator i;
+				
+				// for upped pad buttons
+				for (i = uppedkeys.begin(); i != uppedkeys.end(); i++) {
+					InternalKeyUp(*i, shift);
+				}
+				// for downed pad buttons
+				for (i = downedkeys.begin(); i != downedkeys.end(); i++) {
+					InternalKeyDown(*i, shift);
+				}
+				// for repeated pad buttons
+				for (i = repeatkeys.begin(); i != repeatkeys.end(); i++) {
+					InternalKeyDown(*i, shift | TVP_SS_REPEAT);
+				}
 			}
 		}
 	}
@@ -1543,7 +1546,7 @@ void TTVPWindowForm::CreateDirectInputDevice() {
 	if( !DIPadDevice ) DIPadDevice = new tTVPPadDirectInputDevice(GetHandle());
 #endif
 
-	if ( !SdlInputManager ) SdlInputManager = new tTVPSDLSdlGameControllerMgr(GetHandle());
+	if ( !SdlInputManager && (NULL == tTVPSDLSdlGameControllerMgr::sInstance) ) SdlInputManager = new tTVPSDLSdlGameControllerMgr(GetHandle());
 }
 void TTVPWindowForm::FreeDirectInputDevice() {
 	if( DIWheelDevice ) {

--- a/visual/win32/SDLInputMgr.cpp
+++ b/visual/win32/SDLInputMgr.cpp
@@ -119,6 +119,10 @@ tTVPSDLSdlGameControllerMgr* tTVPSDLSdlGameControllerMgr::sInstance = NULL;
 //---------------------------------------------------------------------------
 tTVPSDLSdlGameControllerMgr::tTVPSDLSdlGameControllerMgr(HWND handle)
 {
+    if (sInstance != NULL)
+    {
+        return;
+    }
     SDL_Init(SDL_INIT_GAMECONTROLLER);
 
     SDL_RWops* file = SDL_RWFromFile("gamecontrollerdb.txt", "rb");
@@ -137,8 +141,11 @@ tTVPSDLSdlGameControllerMgr::tTVPSDLSdlGameControllerMgr(HWND handle)
 //---------------------------------------------------------------------------
 tTVPSDLSdlGameControllerMgr::~tTVPSDLSdlGameControllerMgr()
 {
-    SDL_Quit();
-    sInstance = NULL;
+    if (this == sInstance)
+    {
+        SDL_Quit();
+        sInstance = NULL;
+    }
 }
 
 //---------------------------------------------------------------------------


### PR DESCRIPTION
This resolves the following crashes:  
- When accessing the debug console  
- When closing the `About` window  
